### PR TITLE
Fixing: #Bug: org.json.simple.JSONArrayTest.testObjectArrayToString()…

### DIFF
--- a/src/test/java/org/json/simple/JSONArrayTest.java
+++ b/src/test/java/org/json/simple/JSONArrayTest.java
@@ -282,7 +282,7 @@ public class JSONArrayTest extends TestCase {
 		assertEquals("[\"Hello\"]", writer.toString());
 		
 		writer = new StringWriter();
-		JSONArray.writeJSONString(new Object[] { "Hello", new Integer(12), new int[] { 1, 2, 3} }, writer);
+		JSONArray.writeJSONString(new Object[] { "Hello", Integer.valueOf(12), new int[] { 1, 2, 3} }, writer);
 		assertEquals("[\"Hello\",12,[1,2,3]]", writer.toString());
 	}
 }


### PR DESCRIPTION
… invokes inefficient new Integer(int) constructor; use Integer.valueOf(int) instead

Modified   src/test/java/org/json/simple/JSONArrayTest.java