### PR TITLE
Fix the impossible downcast of toArray().

### DIFF
--- a/src/main/java/org/json/simple/ItemList.java
+++ b/src/main/java/org/json/simple/ItemList.java
@@ -40,7 +40,7 @@ public class ItemList {
 	}
 	
 	public String[] getArray(){
-		return (String[])this.items.toArray();
+		return (String[])this.items.toArray(new String[this.items.size()]);
 	}
 	
 	public void split(String s,String sp,List append,boolean isMultiToken){


### PR DESCRIPTION
This code is casting the result of this.items.toArray() on a list to the String type.
This will usually fail by throwing a ClassCastException. The toArray() of almost all collections return an Object[]. They can't really do anything else, since the Collection object has no reference to the declared generic type of the collection.

The correct and efficient way to get a string  array from a list is to use list.toArray(new String[list.size()]);.
http://findbugs.sourceforge.net/bugDescriptions.html#BC_IMPOSSIBLE_DOWNCAST_OF_TOARRAY