### PR TITLE
Remove the redundant interface.

### DIFF
--- a/src/main/java/org/json/simple/JSONObject.java
+++ b/src/main/java/org/json/simple/JSONObject.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * 
  * @author FangYidong<fangyidong@yahoo.com.cn>
  */
-public class JSONObject extends HashMap implements Map, JSONAware, JSONStreamAware{
+public class JSONObject extends HashMap implements JSONAware, JSONStreamAware{
 	
 	private static final long serialVersionUID = -503443796854799292L;
 	


### PR DESCRIPTION
This class declares that it implements an interface Map which is also implemented by the superclass HashMap.
This is redundant because once a superclass implements an interface, all subclasses by default also implement this interface. It may point out that the inheritance hierarchy has changed since this class was created, and consideration should be given to the ownership of the interface's implementation.
http://findbugs.sourceforge.net/bugDescriptions.html#RI_REDUNDANT_INTERFACES