### PR TITLE
Added way to efficiently navigate through already known JSON schema

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="json-simple" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/org/json/simple/parser/Accessor.java
+++ b/src/main/java/org/json/simple/parser/Accessor.java
@@ -1,0 +1,17 @@
+package org.json.simple.parser;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+/**
+ * Root of classes that can be one of {@link JSONObject} OR {@link JSONArray}
+ * @author <a href="https://github.com/SashaSemenishchev">SashaSemenishchev</a>
+ */
+public interface Accessor {
+    boolean isArray();
+    boolean isJsonObject();
+    boolean isNull();
+
+    JSONObject asJsonObject();
+    JSONArray asArray();
+}

--- a/src/main/java/org/json/simple/parser/JSONParser.java
+++ b/src/main/java/org/json/simple/parser/JSONParser.java
@@ -4,6 +4,7 @@
  */
 package org.json.simple.parser;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.simple.JSONArray;
+import org.json.simple.JSONAware;
 import org.json.simple.JSONObject;
 
 
@@ -71,7 +73,7 @@ public class JSONParser {
 		return lexer.getPosition();
 	}
 	
-	public Object parse(String s) throws ParseException{
+	public Object parse(String s) throws ParseException {
 		return parse(s, (ContainerFactory)null);
 	}
 	
@@ -529,5 +531,27 @@ public class JSONParser {
 		
 		status = S_IN_ERROR;
 		throw new ParseException(getPosition(), ParseException.ERROR_UNEXPECTED_TOKEN, token);
+	}
+
+	/**
+	 * Static accessor of parser for {@link String} input. Used for fast navigation through already known JSON
+	 * @param json A JSON string
+	 * @return Fast JSON navigator
+	 * @author <a href="https://github.com/SashaSemenishchev">SashaSemenishchev</a>
+	 */
+	public static ParseResult of(String json) throws IOException, ParseException {
+		return of(new StringReader(json));
+	}
+
+	/**
+	 * Static accessor of parser for {@link Reader} input. Used for fast navigation through already known JSON
+	 * @param in A {@link Reader} that represents JSON string
+	 * @return Fast JSON navigator
+	 * @author <a href="https://github.com/SashaSemenishchev">SashaSemenishchev</a>
+	 */
+	public static ParseResult of(Reader in) throws IOException, ParseException {
+		JSONParser parser = new JSONParser();
+		JSONAware result = (JSONAware) parser.parse(in);
+		return new ParseResult(result);
 	}
 }

--- a/src/main/java/org/json/simple/parser/ParseResult.java
+++ b/src/main/java/org/json/simple/parser/ParseResult.java
@@ -1,0 +1,150 @@
+package org.json.simple.parser;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONAware;
+import org.json.simple.JSONObject;
+
+/**
+ * Result class of static access {@link JSONParser#of}
+ * Used to fastly navigate through resulted JSON
+ * @author <a href="https://github.com/SashaSemenishchev">SashaSemenishchev</a>
+ */
+public class ParseResult implements Accessor {
+    private final JSONAware result;
+
+    public ParseResult(JSONAware result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @param index The index of resulted array to get
+     * @return Accessor to manipulate output or continue digging into json further
+     */
+    public ParseResultAccessor get(int index) {
+        return new ParseResultAccessor(result, index);
+    }
+
+    /**
+     * @param key The key of the object
+     * @return Accessor to manipulate output or continue digging into json further
+     */
+    public ParseResultAccessor get(String key) {
+        return new ParseResultAccessor(result, key);
+    }
+
+    @Override
+    public boolean isArray() {
+        return result instanceof JSONArray;
+    }
+
+    @Override
+    public boolean isJsonObject() {
+        return result instanceof JSONObject;
+    }
+
+    @Override
+    public boolean isNull() {
+        return result == null;
+    }
+
+    @Override
+    public JSONObject asJsonObject() {
+        return (JSONObject) result;
+    }
+
+    @Override
+    public JSONArray asArray() {
+        return (JSONArray) result;
+    }
+
+    public static class ParseResultAccessor implements Accessor {
+        private Object init;
+
+        public ParseResultAccessor(JSONAware init, int first) {
+            this.init = init;
+            get(first);
+        }
+
+        public ParseResultAccessor(JSONAware init, String first) {
+            this.init = init;
+            get(first);
+        }
+
+        /**
+         * Used if current element is {@link JSONArray} and it's needed to continue by index
+         * @param index Index in the array
+         * @return Array element accessor
+         */
+        public ParseResultAccessor get(int index) {
+            this.init = ((JSONArray)this.init).get(index);
+            return this;
+        }
+
+        /**
+         * Used if current element is {@link JSONObject} and it's needed to continue by string key
+         * @param key Key in the object
+         * @return Object element accessor
+         */
+        public ParseResultAccessor get(String key) {
+            this.init = ((JSONObject)this.init).get(key);
+            return this;
+        }
+
+        /**
+         * Used if it's needed to save current JSON position in the variable, for example to reduce amount of code
+         * when needed objects are in the same root object
+         * @return Parse result on the current point of the accessor
+         */
+        public ParseResult fixate() {
+            return new ParseResult((JSONAware) init);
+        }
+
+        // Methods used to convert current position to needed objects
+
+        public long asInt() {
+            return (long) init;
+        }
+
+        public double asDouble() {
+            return (double) init;
+        }
+
+        public float asFloat() {
+            return (float) init;
+        }
+
+        public long asLong() {
+            return (long) init;
+        }
+
+        public String asString() {
+            return init.toString();
+        }
+
+        @Override
+        public JSONArray asArray() {
+            return (JSONArray) init;
+        }
+
+        @Override
+        public JSONObject asJsonObject() {
+            return (JSONObject) init;
+        }
+
+        @Override
+        public boolean isArray() {
+            return init instanceof JSONArray;
+        }
+
+        @Override
+        public boolean isJsonObject() {
+            return init instanceof JSONObject;
+        }
+
+        @Override
+        public boolean isNull() {
+            return init == null;
+        }
+    }
+}

--- a/src/main/java/org/json/simple/parser/ParseResult.java
+++ b/src/main/java/org/json/simple/parser/ParseResult.java
@@ -118,6 +118,21 @@ public class ParseResult implements Accessor {
             return (long) init;
         }
 
+        public boolean asBoolean() {
+            try {
+                return (boolean) init;
+            } catch (ClassCastException exception) {
+                String val = init.toString();
+                if(val.equalsIgnoreCase("true")) {
+                    return true;
+                } else if(val.equals("false")) {
+                    return false;
+                } else {
+                    throw new ClassCastException("Invalid boolean literal at " + ((JSONAware) init).toJSONString());
+                }
+            }
+        }
+
         public String asString() {
             return init.toString();
         }

--- a/src/test/java/org/json/simple/Test.java
+++ b/src/test/java/org/json/simple/Test.java
@@ -16,10 +16,7 @@ import java.util.Map;
 
 import junit.framework.TestCase;
 
-import org.json.simple.parser.ContainerFactory;
-import org.json.simple.parser.ContentHandler;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import org.json.simple.parser.*;
 
 /**
  * @author FangYidong<fangyidong@yahoo.com.cn>
@@ -293,6 +290,12 @@ public class Test extends TestCase{
         catch(ParseException pe){
             pe.printStackTrace();
         }
+		ParseResult result = JSONParser.of(s);
+		assertEquals(result.get("first").asInt(), 123);
+		assertEquals(result.get("second").get(0).get("k1").get("id").asString(), "id1");
+		assertEquals(result.get("second").get(4).get("id").asInt(), 123);
+		assertEquals(result.get("second").get(1).asInt(), 4);
+		assertTrue(result.get("id").isNull());
 	}
 	
 	public void testEncode() throws Exception{

--- a/src/test/java/org/json/simple/Test.java
+++ b/src/test/java/org/json/simple/Test.java
@@ -263,7 +263,7 @@ public class Test extends TestCase{
             }
         };
         
-        s = "{\"first\": 123, \"second\": [{\"k1\":{\"id\":\"id1\"}}, 4, 5, 6, {\"id\": 123}], \"third\": 789, \"id\": null}";
+        s = "{\"first\": 123, \"second\": [{\"k1\":{\"id\":\"id1\"}}, 4, 5, 6, {\"id\": 123}], \"third\": 789, \"id\": null, \"fourth\": {\"id1\": 987, \"id2\": 1000, \"id3\": false}}";
         parser.reset();
         KeyFinder keyFinder = new KeyFinder();
         keyFinder.setMatchKey("id");
@@ -291,11 +291,16 @@ public class Test extends TestCase{
             pe.printStackTrace();
         }
 		ParseResult result = JSONParser.of(s);
+
 		assertEquals(result.get("first").asInt(), 123);
 		assertEquals(result.get("second").get(0).get("k1").get("id").asString(), "id1");
 		assertEquals(result.get("second").get(4).get("id").asInt(), 123);
 		assertEquals(result.get("second").get(1).asInt(), 4);
 		assertTrue(result.get("id").isNull());
+		ParseResult fourth = result.get("fourth").fixate();
+		assertEquals(fourth.get("id1").asInt(), 987);
+		assertEquals(fourth.get("id2").asInt(), 1000);
+		assertFalse(fourth.get("id3").asBoolean());
 	}
 	
 	public void testEncode() throws Exception{


### PR DESCRIPTION
With my change all users of the lib would be able to efficiently navigate through JSON in Builder-like methods.
Example (from the Test) 
```java
ParseResult result = JSONParser.of("{"first": 123, "second": [{"k1":{"id":"id1"}}, 4, 5, 6, {"id": 123}], "third": 789, "id": null}");
assertEquals(result.get("first").asInt(), 123);
assertEquals(result.get("second").get(0).get("k1").get("id").asString(), "id1");
assertEquals(result.get("second").get(4).get("id").asInt(), 123);
assertEquals(result.get("second").get(1).asInt(), 4);
assertTrue(result.get("id").isNull());
```

Added Accessor interface to represent methods on JSONObject and JSONArray Added 2 static methods in JSONParser to create navigator from String or reader Added tests for them (at the bottom of method testDecode in Test class)

These methods should be only used when user knows what JSON they will be receiving.