### PR TITLE
Add Automatic-Module-Name in Manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>json-simple</artifactId>
   <packaging>bundle</packaging>
   <name>JSON.simple</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>A simple Java toolkit for JSON</description>
   <url>http://code.google.com/p/json-simple/</url>
   <licenses>
@@ -46,9 +46,21 @@
   <build>
       <plugins>
           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <version>3.3.0</version>
+              <configuration>
+                  <archive>
+                      <manifestEntries>
+                          <Automatic-Module-Name>org.json.simple</Automatic-Module-Name>
+                      </manifestEntries>
+                  </archive>
+              </configuration>
+          </plugin>
+          <plugin>
               <groupId>org.apache.felix</groupId>
               <artifactId>maven-bundle-plugin</artifactId>
-              <version>5.1.1</version>
+              <version>5.1.9</version>
               <extensions>true</extensions>
           </plugin>
           <plugin>


### PR DESCRIPTION
With the advent of the module system, it is highly recommended to at least provide an automatic module name in the manifest.
This commit does the minimum to provide it.